### PR TITLE
Make benchmark ONNX runtime setup machine-local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /models/
 /lib/
 .env
+bench/secrets.env
 hindsight.sh
 docs/HINDSIGHT.md
 docs/agentic-reflect-improvements.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "dotenvy",
  "elephant",
  "flate2",
+ "ort",
  "serde",
  "serde_json",
  "sqlx",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,6 +12,7 @@ elephant = { path = ".." }
 chrono = { version = "0.4.44", features = ["serde"] }
 dotenvy = "0.15"
 flate2 = "1.1.2"
+ort = { version = "2.0.0-rc.11", default-features = false, features = ["load-dynamic"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 toml = "0.9.7"

--- a/bench/README.md
+++ b/bench/README.md
@@ -6,7 +6,7 @@ Benchmark config is separate from normal Elephant runtime config:
 
 - root `.env` is for running the Elephant server
 - benchmark behavior comes from checked-in profile TOML files
-- optional execution overlays are TOML and carry machine-local execution settings plus worker shard scope, such as dataset path, benchmark database URL, concurrency, local provider routing, or per-worker subset selection
+- optional execution overlays are TOML and carry machine-local execution settings plus worker shard scope, such as dataset path, benchmark database URL, concurrency, an optional ONNX Runtime dylib override for local models, local provider routing, or per-worker subset selection
 - benchmark secrets live in `bench/secrets.example.env`
 - each benchmark runner also exposes artifact-only `verify` and `doctor` commands for shard and publication hygiene
 

--- a/bench/common/io.rs
+++ b/bench/common/io.rs
@@ -14,7 +14,7 @@ pub fn resolve_workspace_path(path: &Path) -> PathBuf {
     };
     let anchor_to_workspace = matches!(
         first.as_os_str().to_str(),
-        Some("bench" | "data" | "models")
+        Some("bench" | "data" | "models" | "lib")
     );
     if !anchor_to_workspace {
         return path.to_path_buf();
@@ -112,6 +112,12 @@ mod tests {
         assert_eq!(
             resolve_workspace_path(Path::new("models/bge-small-en-v1.5")),
             workspace_root.join("models/bge-small-en-v1.5")
+        );
+        assert_eq!(
+            resolve_workspace_path(Path::new(
+                "lib/onnxruntime-linux-x64-1.23.0/lib/libonnxruntime.so.1.23.0"
+            )),
+            workspace_root.join("lib/onnxruntime-linux-x64-1.23.0/lib/libonnxruntime.so.1.23.0")
         );
     }
 

--- a/bench/locomo/README.md
+++ b/bench/locomo/README.md
@@ -57,10 +57,11 @@ Fill in the keys you need:
 The standard local execution defaults are:
 
 - benchmark Postgres: `postgres://postgres:postgres@localhost:5433/elephant_bench`
+- repo-local ONNX Runtime under `lib/onnxruntime-*/lib` is auto-detected for local embeddings/reranking
 - local embeddings: `models/bge-small-en-v1.5`
 - local reranker: `models/ms-marco-MiniLM-L-6-v2`
 
-Use `--config` only when you need to change execution/provenance settings such as dataset path, output path, concurrency, the benchmark database URL, or local provider routing like `base_url` / Vertex project-location selection.
+Use `--config` only when you need to change execution/provenance settings such as dataset path, output path, concurrency, the benchmark database URL, a custom `ort_dylib_path`, or local provider routing like `base_url` / Vertex project-location selection.
 
 For benchmark hygiene, use an isolated Postgres instance instead of your normal development database. Docker is the easiest option:
 

--- a/bench/longmemeval/README.md
+++ b/bench/longmemeval/README.md
@@ -44,6 +44,7 @@ Fill in the keys you need:
 The standard local execution defaults are:
 
 - benchmark Postgres: `postgres://postgres:postgres@localhost:5433/elephant_bench`
+- repo-local ONNX Runtime under `lib/onnxruntime-*/lib` is auto-detected for local embeddings/reranking
 - local embeddings: `models/bge-small-en-v1.5`
 - local reranker: `models/ms-marco-MiniLM-L-6-v2`
 

--- a/bench/src/config/execution.rs
+++ b/bench/src/config/execution.rs
@@ -115,6 +115,8 @@ pub(crate) struct BenchExecutionOverlayFile {
     #[serde(default)]
     pub(crate) database_url: Option<String>,
     #[serde(default)]
+    pub(crate) ort_dylib_path: Option<PathBuf>,
+    #[serde(default)]
     pub(crate) dataset_path: Option<PathBuf>,
     #[serde(default)]
     pub(crate) output_dir: Option<PathBuf>,
@@ -134,6 +136,7 @@ pub(crate) struct BenchExecutionOverlayFile {
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct BenchExecution {
+    pub(crate) ort_dylib_path: Option<PathBuf>,
     pub(crate) dataset_path: PathBuf,
     pub(crate) output_dir: PathBuf,
     pub(crate) tag: Option<String>,
@@ -152,6 +155,7 @@ impl BenchExecution {
     ) -> Self {
         let overlay = overlay.unwrap_or(BenchExecutionOverlayFile {
             database_url: None,
+            ort_dylib_path: None,
             dataset_path: None,
             output_dir: None,
             tag: None,
@@ -163,6 +167,7 @@ impl BenchExecution {
         });
 
         Self {
+            ort_dylib_path: overlay.ort_dylib_path,
             dataset_path: overlay.dataset_path.unwrap_or(default_dataset_path),
             output_dir: overlay.output_dir.unwrap_or_else(default_output_dir),
             tag: overlay.tag,
@@ -184,6 +189,8 @@ pub(crate) struct LongMemEvalExecutionOverlayFile {
     #[serde(default)]
     pub(crate) database_url: Option<String>,
     #[serde(default)]
+    pub(crate) ort_dylib_path: Option<PathBuf>,
+    #[serde(default)]
     pub(crate) dataset_path: Option<PathBuf>,
     #[serde(default)]
     pub(crate) output_dir: Option<PathBuf>,
@@ -201,6 +208,7 @@ pub(crate) struct LongMemEvalExecutionOverlayFile {
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct LongMemEvalExecution {
+    pub(crate) ort_dylib_path: Option<PathBuf>,
     pub(crate) dataset_path: PathBuf,
     pub(crate) output_dir: PathBuf,
     pub(crate) tag: Option<String>,
@@ -218,6 +226,7 @@ impl LongMemEvalExecution {
     ) -> Self {
         let overlay = overlay.unwrap_or(LongMemEvalExecutionOverlayFile {
             database_url: None,
+            ort_dylib_path: None,
             dataset_path: None,
             output_dir: None,
             tag: None,
@@ -228,6 +237,7 @@ impl LongMemEvalExecution {
         });
 
         Self {
+            ort_dylib_path: overlay.ort_dylib_path,
             dataset_path: overlay.dataset_path.unwrap_or(default_dataset_path),
             output_dir: overlay
                 .output_dir
@@ -256,6 +266,7 @@ mod tests {
             execution.database_url,
             "postgres://postgres:postgres@localhost:5433/elephant_bench"
         );
+        assert_eq!(execution.ort_dylib_path, None);
         assert_eq!(execution.dataset_path, PathBuf::from("data/locomo10.json"));
     }
 
@@ -270,6 +281,7 @@ mod tests {
             execution.database_url,
             "postgres://postgres:postgres@localhost:5433/elephant_bench"
         );
+        assert_eq!(execution.ort_dylib_path, None);
         assert_eq!(
             execution.dataset_path,
             PathBuf::from("data/longmemeval_m_cleaned.json")

--- a/bench/src/config/resolve.rs
+++ b/bench/src/config/resolve.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
+use std::path::PathBuf;
+use std::sync::{Arc, OnceLock};
 
 use serde::Serialize;
 
@@ -19,9 +20,9 @@ use crate::env::BenchJudgeConfig;
 use crate::harness::{BenchHarness, BenchHarnessBuilder};
 
 use super::contract::{
-    BenchmarkKind, JudgeContract, LocomoContractFile, LongMemEvalConsolidationMode,
-    LongMemEvalContractFile, LongMemEvalIngestFormat, ProviderKind, RerankerProviderKind,
-    ResolvedLocomoContract, ResolvedLongMemEvalContract, RuntimeContract,
+    BenchmarkKind, EmbeddingProviderKind, JudgeContract, LocomoContractFile,
+    LongMemEvalConsolidationMode, LongMemEvalContractFile, LongMemEvalIngestFormat, ProviderKind,
+    RerankerProviderKind, ResolvedLocomoContract, ResolvedLongMemEvalContract, RuntimeContract,
 };
 use super::execution::{
     BenchExecution, BenchExecutionOverlayFile, ClientTargetExecution, LocomoShardExecution,
@@ -199,6 +200,7 @@ impl ResolvedBenchConfig {
         build_runtime_config_from_parts(
             &self.contract.runtime,
             &self.execution.database_url,
+            self.execution.ort_dylib_path.as_deref(),
             &self.execution.runtime_target,
             &self.secrets,
         )
@@ -441,6 +443,7 @@ impl ResolvedLongMemEvalBenchConfig {
         build_runtime_config_from_parts(
             &self.contract.runtime,
             &self.execution.database_url,
+            self.execution.ort_dylib_path.as_deref(),
             &self.execution.runtime_target,
             &self.secrets,
         )
@@ -544,6 +547,8 @@ struct RedactedLongMemEvalResolvedBenchConfig<'a> {
 
 #[derive(Debug, Serialize)]
 struct RedactedBenchExecution<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ort_dylib_path: Option<String>,
     dataset_path: String,
     output_dir: String,
     tag: Option<&'a str>,
@@ -561,6 +566,10 @@ struct RedactedBenchExecution<'a> {
 impl<'a> From<&'a BenchExecution> for RedactedBenchExecution<'a> {
     fn from(value: &'a BenchExecution) -> Self {
         Self {
+            ort_dylib_path: value
+                .ort_dylib_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
             dataset_path: value.dataset_path.display().to_string(),
             output_dir: value.output_dir.display().to_string(),
             tag: value.tag.as_deref(),
@@ -576,6 +585,8 @@ impl<'a> From<&'a BenchExecution> for RedactedBenchExecution<'a> {
 
 #[derive(Debug, Serialize)]
 struct RedactedLongMemEvalExecution<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ort_dylib_path: Option<String>,
     dataset_path: String,
     output_dir: String,
     tag: Option<&'a str>,
@@ -592,6 +603,10 @@ struct RedactedLongMemEvalExecution<'a> {
 impl<'a> From<&'a LongMemEvalExecution> for RedactedLongMemEvalExecution<'a> {
     fn from(value: &'a LongMemEvalExecution) -> Self {
         Self {
+            ort_dylib_path: value
+                .ort_dylib_path
+                .as_ref()
+                .map(|path| path.display().to_string()),
             dataset_path: value.dataset_path.display().to_string(),
             output_dir: value.output_dir.display().to_string(),
             tag: value.tag.as_deref(),
@@ -621,10 +636,12 @@ pub fn resolve_locomo_bench_config(
     let overlay = execution_overlay_path
         .map(load_toml::<BenchExecutionOverlayFile>)
         .transpose()?;
-    let execution = BenchExecution::from_overlay(
+    let mut execution = BenchExecution::from_overlay(
         overlay,
         default_locomo_dataset_path(&profile.dataset.identifier)?,
     );
+    execution.ort_dylib_path =
+        resolve_local_ort_dylib_path(&profile.runtime, execution.ort_dylib_path)?;
     validate_execution(&execution)?;
     let secrets = BenchSecrets::load(secrets_env_file)?;
 
@@ -688,10 +705,12 @@ pub fn resolve_longmemeval_bench_config(
     let overlay = execution_overlay_path
         .map(load_toml::<LongMemEvalExecutionOverlayFile>)
         .transpose()?;
-    let execution = LongMemEvalExecution::from_overlay(
+    let mut execution = LongMemEvalExecution::from_overlay(
         overlay,
         default_longmemeval_dataset_path(&profile.dataset.identifier)?,
     );
+    execution.ort_dylib_path =
+        resolve_local_ort_dylib_path(&profile.runtime, execution.ort_dylib_path)?;
     validate_longmemeval_execution(&execution)?;
     let secrets = BenchSecrets::load(secrets_env_file)?;
 
@@ -939,16 +958,19 @@ fn resolve_workspace_path(path: &Path) -> std::path::PathBuf {
     };
     let anchor_to_workspace = matches!(
         first.as_os_str().to_str(),
-        Some("bench" | "data" | "models")
+        Some("bench" | "data" | "models" | "lib")
     );
     if !anchor_to_workspace {
         return path.to_path_buf();
     }
 
+    workspace_root().join(path)
+}
+
+fn workspace_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("bench crate must live under the workspace root")
-        .join(path)
 }
 
 fn validate_profile(profile: &LocomoContractFile) -> Result<()> {
@@ -1229,9 +1251,11 @@ fn ensure_unique_nonblank_ids(name: &str, ids: &[String]) -> Result<()> {
 fn build_runtime_config_from_parts(
     runtime: &RuntimeContract,
     database_url: &str,
+    ort_dylib_path: Option<&Path>,
     runtime_target: &ClientTargetExecution,
     secrets: &BenchSecrets,
 ) -> Result<RuntimeConfig> {
+    initialize_local_ort(runtime, ort_dylib_path)?;
     let llm = build_runtime_llm_config(runtime, runtime_target, secrets)?;
     let embedding = build_embedding_config(runtime, secrets)?;
     let reranker = build_reranker_config(runtime, secrets)?;
@@ -1285,6 +1309,134 @@ fn build_runtime_config_from_parts(
             tuning.retrieval.retriever_limit,
             tuning.retrieval.max_facts,
         )?)
+}
+
+fn needs_local_ort(runtime: &RuntimeContract) -> bool {
+    runtime.embedding.provider == EmbeddingProviderKind::Local
+        || runtime.reranker.provider == RerankerProviderKind::Local
+}
+
+fn resolve_local_ort_dylib_path(
+    runtime: &RuntimeContract,
+    ort_dylib_path: Option<PathBuf>,
+) -> Result<Option<PathBuf>> {
+    if !needs_local_ort(runtime) {
+        return Ok(None);
+    }
+
+    if let Some(path) = ort_dylib_path {
+        validate_ort_dylib_path(&path)?;
+        return Ok(Some(path));
+    }
+
+    let discovered = discover_repo_local_ort_dylib_path().ok_or_else(|| {
+        ConfigError::configuration(
+            "local embeddings or reranking require ONNX Runtime; set execution.ort_dylib_path or install a repo-local ONNX Runtime under lib/onnxruntime-*/lib"
+        )
+    })?;
+    Ok(Some(discovered))
+}
+
+fn validate_ort_dylib_path(path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        return Err(ConfigError::configuration(
+            "execution.ort_dylib_path must not be blank",
+        ));
+    }
+
+    let resolved = resolve_workspace_path(path);
+    if !resolved.is_file() {
+        return Err(ConfigError::configuration(format!(
+            "execution.ort_dylib_path does not point to a file: {}",
+            resolved.display()
+        )));
+    }
+    Ok(())
+}
+
+fn discover_repo_local_ort_dylib_path() -> Option<PathBuf> {
+    let lib_root = resolve_workspace_path(Path::new("lib"));
+    let entries = fs::read_dir(lib_root).ok()?;
+    let mut candidates = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .filter_map(|dir| {
+            let name = dir.file_name()?.to_str()?;
+            if !name.starts_with("onnxruntime-") {
+                return None;
+            }
+            let dylib_dir = dir.join("lib");
+            let dylib_entries = fs::read_dir(dylib_dir).ok()?;
+            let mut dylibs = dylib_entries
+                .flatten()
+                .map(|entry| entry.path())
+                .filter(|path| path.is_file())
+                .filter(|path| {
+                    path.file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(is_ort_dylib_filename)
+                })
+                .collect::<Vec<_>>();
+            dylibs.sort();
+            dylibs
+                .into_iter()
+                .next()
+                .and_then(|path| path.strip_prefix(workspace_root()).ok().map(PathBuf::from))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.into_iter().next()
+}
+
+fn is_ort_dylib_filename(name: &str) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        name.eq_ignore_ascii_case("onnxruntime.dll")
+    }
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        name == "libonnxruntime.so" || name.starts_with("libonnxruntime.so.")
+    }
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        name == "libonnxruntime.dylib" || name.starts_with("libonnxruntime.")
+    }
+}
+
+fn initialize_local_ort(runtime: &RuntimeContract, ort_dylib_path: Option<&Path>) -> Result<()> {
+    static ORT_DYLIB_INIT: OnceLock<PathBuf> = OnceLock::new();
+
+    if !needs_local_ort(runtime) {
+        return Ok(());
+    }
+
+    let ort_dylib_path = ort_dylib_path.ok_or_else(|| {
+        ConfigError::configuration(
+            "local embeddings or reranking require a resolved execution.ort_dylib_path",
+        )
+    })?;
+    let resolved = resolve_workspace_path(ort_dylib_path);
+
+    if let Some(existing) = ORT_DYLIB_INIT.get() {
+        if existing == &resolved {
+            return Ok(());
+        }
+        return Err(ConfigError::configuration(format!(
+            "ONNX Runtime was already initialized from {} and cannot be reconfigured to {} in the same benchmark process",
+            existing.display(),
+            resolved.display()
+        )));
+    }
+
+    let _ = ort::init_from(&resolved).map_err(|error| {
+        ConfigError::configuration(format!(
+            "failed to preload ONNX Runtime from {}: {error}",
+            resolved.display()
+        ))
+    })?;
+    let _ = ORT_DYLIB_INIT.set(resolved);
+    Ok(())
 }
 
 fn build_judge_config_from_parts(
@@ -1629,6 +1781,33 @@ question_jobs = 4
         assert!(printed.contains("\"contract_hash\""));
         assert!(!printed.contains("runtime-secret"));
         assert!(!printed.contains("judge-secret"));
+    }
+
+    #[test]
+    fn resolves_locomo_config_and_auto_discovers_repo_local_ort_path() {
+        let _guard = env_lock().lock().unwrap();
+
+        let profile = temp_path("profile.toml");
+        let overlay = temp_path("overlay.toml");
+        let dataset = temp_path("dataset.json");
+        let secrets = temp_path("secrets.env");
+
+        write_file(&profile, &sample_profile());
+        write_file(&dataset, r#"{"sample":"ok"}"#);
+        write_file(&overlay, &sample_overlay(&dataset));
+        write_file(
+            &secrets,
+            "ELEPHANT_BENCH_RUNTIME_API_KEY=runtime-secret\nELEPHANT_BENCH_JUDGE_API_KEY=judge-secret\n",
+        );
+
+        let resolved =
+            resolve_locomo_bench_config(&profile, Some(&overlay), Some(&secrets)).unwrap();
+
+        let expected = discover_repo_local_ort_dylib_path().unwrap();
+        assert_eq!(
+            resolved.redacted_execution_json()["ort_dylib_path"],
+            serde_json::Value::String(expected.display().to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat the ONNX runtime dylib as machine-local benchmark execution config instead of ambient shell state
- auto-discover a repo-local ONNX Runtime under , with optional  execution override
- preload the resolved ORT dylib explicitly for local benchmark embeddings/reranking and document the new behavior

## Verification
- 
running 22 tests
test config::execution::tests::locomo_execution_defaults_support_standard_local_benchmark_setup ... ok
test config::execution::tests::longmemeval_execution_defaults_support_standard_local_benchmark_setup ... ok
test config::resolve::tests::default_longmemeval_dataset_path_is_profile_aware ... ok
test config::resolve::tests::noncanonical_profile_path_skips_explicitness_lint ... ok
test config::resolve::tests::canonical_profile_lint_rejects_missing_explicit_contract_fields ... ok
test env::tests::bench_config_new_preserves_requirement ... ok
test env::tests::judge_config_debug_redacts_client_secrets ... ok
test env::tests::judge_config_new_uses_validated_client ... ok
test harness::tests::metadata_rejects_embedding_dimensions_over_u16_max ... ok
test config::resolve::tests::unknown_profile_field_fails_fast ... ok
test config::resolve::tests::missing_secrets_fail_with_field_name ... ok
test config::resolve::tests::contract_hash_ignores_execution_concurrency ... ok
test config::resolve::tests::cli_dataset_override_updates_execution_and_contract_hash ... ok
test config::resolve::tests::contract_hash_ignores_local_routing_targets_but_execution_records_them ... ok
test config::resolve::tests::contract_hash_ignores_locomo_shard_scope_but_execution_records_it ... ok
test config::resolve::tests::locomo_shard_conversations_must_stay_within_contract_slice ... ok
test config::resolve::tests::longmemeval_overlay_shard_offset_survives_without_cli_override ... ok
test config::resolve::tests::longmemeval_shard_scope_is_execution_only ... ok
test config::resolve::tests::resolves_locomo_config_and_auto_discovers_repo_local_ort_path ... ok
test config::resolve::tests::vertex_provider_requires_local_project ... ok
test config::resolve::tests::resolves_locomo_config_and_hash_is_stable ... ok
test config::resolve::tests::vertex_runtime_provider_uses_local_execution_target ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 52 tests
test common::failure::tests::llm_refusal_is_not_fatal ... ok
test common::failure::tests::provider_400_is_fatal ... ok
test common::failure::tests::rate_limit_is_not_fatal ... ok
test common::failure::tests::provider_response_parse_change_is_fatal ... ok
test common::fingerprint::tests::different_input_different_hash ... ok
test common::fingerprint::tests::deterministic_across_calls ... ok
test common::fingerprint::tests::empty_input_returns_offset_basis ... ok
test common::fingerprint::tests::hex_deterministic ... ok
test common::fingerprint::tests::hex_returns_16_char_string ... ok
test common::io::tests::resolve_workspace_path_leaves_non_bench_paths_unchanged ... ok
test common::io::tests::resolve_workspace_path_rewrites_logical_bench_paths ... ok
test common::io::tests::resolve_workspace_path_rewrites_repo_relative_data_and_model_paths ... ok
test common::io::tests::sidecar_path_format ... ok
test common::io::tests::sidecar_path_no_parent ... ok
test common::io::tests::append_jsonl_creates_and_appends ... ok
test tests::default_merge_output_uses_local_directory ... ok
test tests::computes_evidence_recall_on_unique_refs ... ok
test tests::default_publish_output_uses_published_directory ... ok
test tests::default_tagged_run_output_uses_local_directory ... ok
test tests::excludes_category_five_even_when_answer_is_present ... ok
test tests::default_run_output_uses_local_directory ... ok
test tests::includes_answered_category_four_questions ... ok
test tests::ignores_generated_benchmark_result_paths_in_dirty_check ... ok
test tests::blocks_overwriting_existing_fresh_output_without_force ... ok
test tests::latest_session_temporal_context_uses_latest_valid_session_date ... ok
test tests::merge_force_sets_allow_overwrite ... ok
test tests::merge_loads_input_artifacts_and_output_override ... ok
test tests::parse_doctor_requires_one_input ... ok
test tests::parse_doctor_subcommand ... ok
test tests::parse_verify_requires_one_input ... ok
test tests::parse_verify_subcommand ... ok
test tests::publish_loads_input_artifact_and_options ... ok
test tests::qa_defaults_to_source_artifact_path ... ok
test tests::merge_output_must_differ_from_inputs_without_force ... ok
test tests::reads_plain_session_keys_from_locomo_variant ... ok
test tests::removed_alias_falls_back_to_unknown_argument ... ok
test tests::session_count_ignores_summary_and_observation_keys ... ok
test tests::smoke_profile_loads_expected_defaults ... ok
test tests::qa_rejects_protocol_overrides ... ok
test tests::qa_blocks_in_place_artifact_update_without_force ... ok
test tests::unknown_subcommand_is_rejected ... ok
test tests::qa_loads_scope_from_artifact_manifest ... ok
test tests::qa_allows_execution_overrides ... ok
test tests::doctor_rejects_incomplete_explicit_conversation_coverage ... ok
test tests::verify_rejects_selected_conversation_drift ... ok
test tests::publish_exports_summary_questions_and_index ... ok
test tests::doctor_accepts_full_explicit_conversation_coverage ... ok
test tests::verify_accepts_disjoint_same_contract_shards ... ok
test tests::merge_allows_provenance_field_differences ... ok
test tests::merge_combines_disjoint_subset_artifacts ... ok
test tests::merge_allows_identical_duplicate_question_and_debug_records ... ok
test tests::shard_workflow_merges_disjoint_runs_under_one_contract ... ok

test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 150 tests
test common::failure::tests::llm_refusal_is_not_fatal ... ok
test common::failure::tests::provider_400_is_fatal ... ok
test common::failure::tests::rate_limit_is_not_fatal ... ok
test common::failure::tests::provider_response_parse_change_is_fatal ... ok
test common::fingerprint::tests::different_input_different_hash ... ok
test common::fingerprint::tests::deterministic_across_calls ... ok
test common::fingerprint::tests::empty_input_returns_offset_basis ... ok
test common::fingerprint::tests::hex_deterministic ... ok
test common::fingerprint::tests::hex_returns_16_char_string ... ok
test common::io::tests::resolve_workspace_path_leaves_non_bench_paths_unchanged ... ok
test common::io::tests::resolve_workspace_path_rewrites_logical_bench_paths ... ok
test common::io::tests::resolve_workspace_path_rewrites_repo_relative_data_and_model_paths ... ok
test common::io::tests::sidecar_path_format ... ok
test common::io::tests::append_jsonl_creates_and_appends ... ok
test common::io::tests::sidecar_path_no_parent ... ok
test dataset::tests::answer_fallback_from_bool ... ok
test dataset::tests::answer_number_from_int ... ok
test dataset::tests::answer_string_from_string ... ok
test dataset::tests::deserialize_multi_session ... ok
test dataset::tests::deserialize_knowledge_update ... ok
test dataset::tests::deserialize_single_session_assistant ... ok
test dataset::tests::deserialize_single_session_preference ... ok
test dataset::tests::deserialize_single_session_user ... ok
test dataset::tests::deserialize_temporal_reasoning ... ok
test dataset::tests::is_abstention_without_abs ... ok
test dataset::tests::is_abstention_with_abs_suffix ... ok
test dataset::tests::load_dataset_missing_file_gives_helpful_error ... ok
test dataset::tests::reporting_category_abstention ... ok
test dataset::tests::reporting_category_normal ... ok
test dataset::tests::validate_catches_null_answer ... ok
test dataset::tests::validate_catches_session_date_length_mismatch ... ok
test dataset::tests::validate_catches_session_id_length_mismatch ... ok
test dataset::tests::validate_collects_all_errors ... ok
test dataset::tests::validate_passes_for_valid_instance ... ok
test ingest::tests::consolidation_mode_end_enabled ... ok
test ingest::tests::consolidation_mode_end_not_per_session ... ok
test ingest::tests::consolidation_mode_off_not_enabled ... ok
test ingest::tests::consolidation_mode_per_session_enabled ... ok
test ingest::tests::consolidation_mode_per_session_is_per_session ... ok
test ingest::tests::format_session_json_no_has_answer ... ok
test ingest::tests::format_session_json_produces_array ... ok
test ingest::tests::format_session_text_produces_date_prefix ... ok
test ingest::tests::ingest_config_default ... ok
test ingest::tests::format_session_text_multiple_turns_joined ... ok
test ingest::tests::ingest_config_missing_session_limit_deserializes_to_none ... ok
test ingest::tests::ingest_config_session_limit_roundtrip ... ok
test ingest::tests::ingest_stats_default ... ok
test ingest::tests::ingest_timing_default ... ok
test ingest::tests::parse_date_prefix_full_format ... ok
test ingest::tests::parse_date_prefix_new_year ... ok
test ingest::tests::parse_haystack_date_date_only_fallback ... ok
test ingest::tests::parse_haystack_date_full_format ... ok
test ingest::tests::ingest_result_roundtrip ... ok
test ingest::tests::parse_haystack_date_new_year ... ok
test tests::accuracy_all_correct ... ok
test tests::accuracy_all_wrong ... ok
test tests::accuracy_empty ... ok
test tests::accuracy_mixed ... ok
test tests::accuracy_with_errors_counted_wrong ... ok
test tests::bench_command_as_str ... ok
test tests::benchmark_artifacts_serde_roundtrip ... ok
test tests::category_result_serde_roundtrip ... ok
test tests::benchmark_output_without_instance_status_deserializes ... ok
test tests::cli_overrides_apply_overrides_set_fields ... ok
test tests::default_output_ingest_with_tag ... ok
test tests::default_output_merge_no_tag ... ok
test tests::benchmark_manifest_serde_roundtrip ... ok
test tests::default_output_qa_no_tag_returns_artifact ... ok
test tests::default_output_merge_with_tag ... ok
test tests::default_output_run_smoke_no_tag ... ok
test tests::default_output_with_explicit_out ... ok
test tests::benchmark_output_with_instance_status_roundtrip ... ok
test tests::benchmark_output_serde_roundtrip ... ok
test tests::consolidation_mode_as_str ... ok
test tests::cli_overrides_apply_preserves_unset_fields ... ok
test tests::compute_per_category_groups_and_counts ... ok
test tests::consolidation_mode_from_str ... ok
test tests::ingest_format_as_str ... ok
test tests::ingest_format_from_str ... ok
test tests::instance_status_default_is_empty ... ok
test tests::instance_status_serde_roundtrip ... ok
test tests::judge_prompt_hash_deterministic ... ok
test tests::parse_config_path ... ok
test tests::parse_doctor_subcommand ... ok
test tests::parse_contract_override_flags_are_rejected_for_run ... ok
test tests::parse_doctor_requires_one_input ... ok
test tests::parse_force ... ok
test tests::parse_help_returns_none ... ok
test tests::merge_output_must_differ_from_inputs_without_force ... ok
test tests::parse_ingest_subcommand ... ok
test tests::parse_merge_requires_two_inputs ... ok
test tests::parse_instance_jobs ... ok
test tests::parse_merge_with_out ... ok
test tests::parse_merge_rejects_instance_jobs ... ok
test tests::load_benchmark_output_parses_valid_json ... ok
test tests::parse_merge_subcommand ... ok
test tests::parse_merge_with_tag ... ok
test tests::parse_merge_rejects_profile ... ok
test tests::parse_missing_subcommand_is_error ... ok
test tests::parse_out ... ok
test tests::parse_profile_smoke ... ok
test tests::parse_qa_missing_path_is_error ... ok
test tests::parse_resume ... ok
test tests::parse_resume_and_force_mutually_exclusive ... ok
test tests::parse_run_subcommand ... ok
test tests::parse_shard_override_flags_are_allowed_for_run ... ok
test tests::parse_tag ... ok
test tests::doctor_rejects_incomplete_explicit_instance_coverage ... ok
test tests::parse_unknown_subcommand_is_error ... ok
test tests::parse_verify_subcommand ... ok
test tests::parse_verify_requires_one_input ... ok
test tests::qa_allows_execution_overrides ... ok
test tests::qa_rejects_profile ... ok
test tests::qa_rejects_protocol_flags ... ok
test tests::question_debug_record_serde_roundtrip ... ok
test tests::question_result_serde_roundtrip ... ok
test tests::resolve_fresh_config_keeps_profile_and_overrides_only ... ok
test tests::render_judge_prompt_replaces_placeholders ... ok
test tests::run_config_from_artifact_extracts_config ... ok
test tests::run_profile_as_str ... ok
test tests::run_profile_config_path ... ok
test tests::run_profile_from_str ... ok
test tests::parse_qa_subcommand_with_path ... ok
test tests::run_profile_default_is_full_s ... ok
test tests::safety_allows_nonexistent_output ... ok
test tests::select_judge_prompt_abstention ... ok
test tests::safety_allows_with_force ... ok
test tests::select_judge_prompt_factual ... ok
test tests::merge_rejects_overlapping_questions ... ok
test tests::safety_blocks_existing_output ... ok
test tests::safety_qa_blocks_overwriting_source_artifact ... ok
test tests::select_judge_prompt_preference ... ok
test tests::select_judge_prompt_knowledge_update ... ok
test tests::git_commit_sha_returns_some ... ok
test tests::select_judge_prompt_multi_session ... ok
test tests::merge_rejects_mismatched_contract_hashes ... ok
test tests::select_judge_prompt_temporal ... ok
test tests::source_artifact_serde_roundtrip ... ok
test tests::select_judge_prompt_ssa ... ok
test tests::doctor_accepts_full_explicit_instance_coverage ... ok
test tests::verify_rejects_selected_instance_drift ... ok
test tests::verify_accepts_disjoint_same_contract_shards ... ok
test tests::resolve_qa_config_applies_shard_window_overrides ... ok
test tests::git_dirty_worktree_returns_some ... ok
test tests::merge_combines_disjoint_subset_artifacts ... ok
test tests::resolve_longmemeval_smoke_profile_contract ... ok
test tests::apply_resolved_fresh_config_cli_jobs_override_beats_execution_overlay ... ok
test tests::apply_resolved_fresh_config_uses_contract_and_execution_defaults ... ok
test tests::longmemeval_judge_override_changes_contract_hash ... ok
test tests::shard_workflow_merges_disjoint_runs_under_one_contract ... ok

test result: ok. 150 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.25s


running 31 tests
test common::failure::tests::llm_refusal_is_not_fatal ... ok
test common::failure::tests::provider_response_parse_change_is_fatal ... ok
test common::failure::tests::provider_400_is_fatal ... ok
test common::fingerprint::tests::deterministic_across_calls ... ok
test common::failure::tests::rate_limit_is_not_fatal ... ok
test common::fingerprint::tests::different_input_different_hash ... ok
test common::fingerprint::tests::empty_input_returns_offset_basis ... ok
test common::fingerprint::tests::hex_deterministic ... ok
test common::fingerprint::tests::hex_returns_16_char_string ... ok
test common::io::tests::resolve_workspace_path_leaves_non_bench_paths_unchanged ... ok
test common::io::tests::resolve_workspace_path_rewrites_logical_bench_paths ... ok
test common::io::tests::resolve_workspace_path_rewrites_repo_relative_data_and_model_paths ... ok
test common::io::tests::append_jsonl_creates_and_appends ... ok
test common::io::tests::sidecar_path_format ... ok
test common::io::tests::sidecar_path_no_parent ... ok
test tests::test_build_stage_rows ... ok
test tests::test_deserialize_question_result ... ok
test tests::test_deserialize_stage_usage_legacy_aliases ... ok
test tests::test_deserialize_benchmark_output ... ok
test tests::test_file_label_from_path ... ok
test tests::test_file_label_with_tag ... ok
test tests::test_deserialize_with_missing_fields ... ok
test tests::test_fmt_cost_delta_u64 ... ok
test tests::test_fmt_time ... ok
test tests::test_fmt_pct ... ok
test tests::test_format_category_rows ... ok
test tests::test_format_category_rows_comparison ... ok
test tests::test_parse_args_comparison ... ok
test tests::test_parse_args_single_file ... ok
test tests::test_parse_args_verbose ... ok
test tests::test_view_stage_usage_total_tokens ... ok

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 39 tests
test common::failure::tests::llm_refusal_is_not_fatal ... ok
test common::failure::tests::provider_400_is_fatal ... ok
test common::failure::tests::provider_response_parse_change_is_fatal ... ok
test common::failure::tests::rate_limit_is_not_fatal ... ok
test common::fingerprint::tests::deterministic_across_calls ... ok
test common::fingerprint::tests::different_input_different_hash ... ok
test common::fingerprint::tests::empty_input_returns_offset_basis ... ok
test common::fingerprint::tests::hex_deterministic ... ok
test common::fingerprint::tests::hex_returns_16_char_string ... ok
test common::io::tests::resolve_workspace_path_leaves_non_bench_paths_unchanged ... ok
test common::io::tests::resolve_workspace_path_rewrites_logical_bench_paths ... ok
test common::io::tests::resolve_workspace_path_rewrites_repo_relative_data_and_model_paths ... ok
test common::io::tests::sidecar_path_format ... ok
test common::io::tests::append_jsonl_creates_and_appends ... ok
test common::io::tests::sidecar_path_no_parent ... ok
test dataset::tests::answer_fallback_from_bool ... ok
test dataset::tests::answer_number_from_int ... ok
test dataset::tests::answer_string_from_string ... ok
test dataset::tests::deserialize_knowledge_update ... ok
test dataset::tests::deserialize_multi_session ... ok
test dataset::tests::deserialize_single_session_assistant ... ok
test dataset::tests::deserialize_single_session_preference ... ok
test dataset::tests::deserialize_single_session_user ... ok
test dataset::tests::deserialize_temporal_reasoning ... ok
test dataset::tests::is_abstention_with_abs_suffix ... ok
test dataset::tests::is_abstention_without_abs ... ok
test dataset::tests::load_dataset_missing_file_gives_helpful_error ... ok
test dataset::tests::reporting_category_abstention ... ok
test dataset::tests::reporting_category_normal ... ok
test dataset::tests::validate_catches_null_answer ... ok
test dataset::tests::validate_catches_session_date_length_mismatch ... ok
test dataset::tests::validate_catches_session_id_length_mismatch ... ok
test dataset::tests::validate_collects_all_errors ... ok
test test_fingerprint_determinism ... ignored
test test_load_m ... ignored
test test_load_s ... ignored
test dataset::tests::validate_passes_for_valid_instance ... ok
test test_question_type_distribution ... ignored
test test_missing_file_error ... ok

test result: ok. 35 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
